### PR TITLE
Handling of huge decorators (a case for the Plotly.Dash projects)

### DIFF
--- a/queries/python/folds.scm
+++ b/queries/python/folds.scm
@@ -57,6 +57,12 @@
     ) @fold
 )
 
+; Fold multiline decorators
+(decorator
+    (call
+    ) @fold
+)
+
 
 ; Old default folds
 ;(while_statement (block) @fold)


### PR DESCRIPTION
A small addition for TS SCM file for handling multiline @decorators, which is annoying me while building stuff for https://dash.plotly.com/. Smaller decorators, remain untouched.

Turns this:
![image](https://user-images.githubusercontent.com/18488560/225294125-dddaf72d-9b83-4db4-a3c9-e182c92aa318.png)

Into this:
![image](https://user-images.githubusercontent.com/18488560/225294241-d6a9af8e-f067-451c-8ce6-d5d0a6df522e.png)
